### PR TITLE
+/-INF is not valid JSON

### DIFF
--- a/skins/Mesowx/meso/stats.php
+++ b/skins/Mesowx/meso/stats.php
@@ -162,7 +162,7 @@ abstract class CompareTracker {
 }
 class MaxTracker extends CompareTracker {
     function __construct() {
-        parent::__construct(-INF); // minimum int value
+        parent::__construct(-1e99); // minimum int value
     }
     protected function compare( $newValue, $oldValue ) {
         return $newValue > $oldValue;
@@ -173,7 +173,7 @@ class MaxTracker extends CompareTracker {
 }
 class MinTracker extends CompareTracker {
     function __construct() {
-        parent::__construct(INF);
+        parent::__construct(1e99);
     }
     protected function compare( $newValue, $oldValue ) {
         return $newValue < $oldValue;


### PR DESCRIPTION
I had a problem with the min and max values not being displayed.  It turns out the +/-INF is not valid JSON.  The issue showed up in the rainRate values: "rainRate":{"max":[-INF,null]} which triggered an error.  Substituting 1e99 for INF seems to be an adequate work around.  However, there is likely a better fix, but this works.